### PR TITLE
Fix: Prevent initial notifications and simplify navbar

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -127,17 +127,6 @@ const Layout: FC<LayoutProps> = ({ children, onLogout }) => {
         </a>
         <div className="navbar-collapse justify-content-end p-2">
           <ul className="navbar-nav">
-            <li className="nav-item w-25">
-              {" "}
-              {/* Estas clases w-25 parecen mucho para cada item */}
-              <a className={`nav-link p-2 ${styles.nav_link}`}>Home</a> {/* Removido w-50 innecesario aquí */}
-            </li>
-            <li className="nav-item w-25">
-              <a className={`nav-link p-2 ${styles.nav_link}`}>About</a>
-            </li>
-            <li className="nav-item w-25">
-              <a className={`nav-link p-2 ${styles.nav_link}`}>Services</a>
-            </li>
             {/* El botón de "Notifications" que generaba las locales ha sido removido */}
             <li className="nav-item w-25">
               <a className={`nav-link p-2 ${styles.nav_link}`} onClick={onLogout}>

--- a/src/components/PollingOrchestrator/PollingOrchestrator.tsx
+++ b/src/components/PollingOrchestrator/PollingOrchestrator.tsx
@@ -51,6 +51,13 @@ const PollingOrchestrator: React.FC = () => {
       const oldCveMap =
         previousCveProbsRef.current.get(agentPolicyKey) || new Map();
 
+      // Si el mapa de CVEs previos para esta clave está vacío, es la primera vez que se carga.
+      // En este caso, solo almacenamos los datos actuales y no notificamos.
+      if (oldCveMap.size === 0) {
+        previousCveProbsRef.current.set(agentPolicyKey, newCveMap);
+        return; // No notificar en la primera carga de datos para esta clave.
+      }
+
       let cveChangesDetected = false;
       let cveChangeDetails = `Agente ${agentName} (Política ${policyId}): `;
       const addedOrChanged: string[] = [];

--- a/src/context/FailedCheckContext.tsx
+++ b/src/context/FailedCheckContext.tsx
@@ -61,6 +61,18 @@ export const FailedChecksProvider: React.FC<{ children: ReactNode }> = ({
         let oldFailedChecksSet = new Set<number>();
         if (existingAgentCheckData) {
           oldFailedChecksSet = existingAgentCheckData.failedChecks;
+        } else {
+          // Si no hay datos existentes, es la primera vez que se carga.
+          // Almacenamos los datos y no hacemos nada más.
+          const initialAgentCheckData: AgentCheckData = {
+            agentId,
+            agentName,
+            policyId,
+            failedChecks: newFailedChecksSet,
+            lastUpdate: now,
+          };
+          newMap.set(mapKey, initialAgentCheckData);
+          return newMap;
         }
         // ---> AQUÍ PUEDES VER LA COMPARACIÓN <---
         console.log(


### PR DESCRIPTION
This commit addresses two issues:

1.  It prevents notifications from being sent on the initial page load by checking if the previous state was empty.
2.  It simplifies the navbar by removing the "Home", "About", and "Services" links, leaving only the "Logout" button.